### PR TITLE
Add check for device tree NoCutoutOverlay

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -172,8 +172,9 @@ PRODUCT_PACKAGES += \
     StitchImage
 
 # Cutout control overlay
-PRODUCT_PACKAGES += \
-    NoCutoutOverlay
+ifneq ($(filter true, $(TARGET_PROVIDES_OWN_NO_CUTOUT_OVERLAY)),)
+PRODUCT_PACKAGES += NoCutoutOverlay
+endif
 
 # Branding
 include vendor/aosp/config/branding.mk

--- a/packages/overlays/NoCutoutOverlay/Android.mk
+++ b/packages/overlays/NoCutoutOverlay/Android.mk
@@ -8,4 +8,7 @@ LOCAL_SDK_VERSION := current
 LOCAL_CERTIFICATE := platform
 LOCAL_PRIVILEGED_MODULE := false
 
+ifneq ($(filter true, $(TARGET_PROVIDES_OWN_NO_CUTOUT_OVERLAY)),)
 include $(BUILD_PACKAGE)
+endif
+


### PR DESCRIPTION
I decided to add this flag in so that devices can use their DT version of it instead of Evo's version of it. I think having to delete the Evo-X version of it each time is annoying, so using this flag, people can say that they already have their own NoCutoutOverlay.